### PR TITLE
Ensure education and experience details visible on mobile

### DIFF
--- a/src/components/Education.jsx
+++ b/src/components/Education.jsx
@@ -93,6 +93,12 @@ const Education = () => {
         <div className="flex justify-end z-10 sm:block hidden">
           <EducationDetails education={selectedEducation} />
         </div>
+
+        {isMobile && (
+          <div className="flex justify-end z-10 sm:hidden w-full">
+            <EducationDetails education={selectedEducation} />
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/components/Experience.jsx
+++ b/src/components/Experience.jsx
@@ -92,6 +92,12 @@ const Experience = () => {
         <div className="flex justify-end z-10 sm:block hidden">
           <ExperienceDetails experience={selectedJob} />
         </div>
+
+        {isMobile && (
+          <div className="flex justify-end z-10 sm:hidden w-full">
+            <ExperienceDetails experience={selectedJob} />
+          </div>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- render education details in a dedicated mobile block so selected items remain readable on phones
- mirror the same responsive handling for the experience section to keep bullet lists visible under 640px

## Testing
- Manual verification in browser at 400px width

------
https://chatgpt.com/codex/tasks/task_e_68e69f9cca588323940938b0339cf837